### PR TITLE
Bug fixed: Facebook OpenGraph tags

### DIFF
--- a/layouts/partials/headers.html
+++ b/layouts/partials/headers.html
@@ -56,27 +56,24 @@
 <link rel="alternate" href="{{ "/index.xml" | absURL }}" type="application/rss+xml" title="{{ .Site.Title }}">
 
 <!-- Facebook OpenGraph tags -->
+<!-- Modifiqué esta parte y la de Twitter porque sólo hacía referencia a imágenes en el folder static. Lo simplifiqué -->
+<!-- Esto lo hice para que los artículo del blog fuesen autocontenidos (incluyendo sus imágenes) -->
 {{ $is_blog := and (eq .Type "blog") (eq .Kind "page") }}
 {{ $has_image :=  isset .Params "banner" }}
-{{ $image := cond $has_image .Params.banner (.Site.Params.default_sharing_image | default "img/sharing-default.png") }}
-{{ $is_valid_image := print "static/" $image | fileExists }}
-{{ if $is_valid_image }}
-{{ $image_ext := path.Ext $image }}
+
+{{ if $has_image }}
+<!-- <meta property="debug-params-banner" content="{{ urls.JoinPath .Permalink .Params.banner }}"> -->
+{{ $path_del_banner := urls.JoinPath .Permalink .Params.banner }}
+
 <meta property="og:locale" content="{{ replace .Site.LanguageCode "-" "_" }}">
 <meta property="og:site_name" content="{{ .Site.Title }}">
 <meta property="og:title" content="{{ $title_plain }}">
 <meta property="og:type" content="{{ cond $is_blog "article" "website" }}">
 <meta property="og:url" content="{{ .Permalink }}" />
 <meta property="og:description" content="{{ $description_plain }}">
-<meta property="og:image" content="{{ $image | absURL }}">
-<meta property="og:image:type" content="image/{{ if eq $image_ext ".svg" }}svg+xml{{ else }}{{ trim $image_ext "." }}{{ end }}">
-{{ with .Params.banner_alt }}<meta property="og:image:alt" content="{{ . | markdownify | plainify }}">{{ end }}
-{{ $image_local :=  printf "/static/%s" $image}}
-{{ with (imageConfig $image_local) }}
-  <meta property="og:image:width" content="{{ .Width }}">
-  <meta property="og:image:height" content="{{ .Height }}">
+<meta property="og:image" content="{{ $path_del_banner }}">
 {{ end }}
-{{ end }}
+
 {{ with .Lastmod }}<meta property="og:updated_time" content="{{ .Format "2006-01-02T15:04:05Z0700" }}">{{ end }}
 {{ if $is_blog }}
   {{ with .Param "facebook_site" }}<meta property="article:publisher" content="https://www.facebook.com/{{ . }}/">{{ end }}
@@ -90,11 +87,12 @@
 {{ end }}
 
 <!-- Twitter Card meta tags -->
-<meta name="twitter:card" content="summary{{ if (and $is_blog (and $has_image $is_valid_image)) }}_large_image{{ end }}">
+<meta name="twitter:card" content="summary{{ if (and $is_blog (and $has_image)) }}_large_image{{ end }}">
 {{ with .Param "twitter_site" }}<meta name="twitter:site" content="@{{ . }}">{{ end }}
 <meta name="twitter:title" content="{{ $title_plain | truncate 70 }}">
-{{ if $is_valid_image }}
-<meta name="twitter:image" content="{{ $image | absURL }}">
+{{ if $has_image }}
+{{ $path_del_banner := urls.JoinPath .Permalink .Params.banner }}
+<meta name="twitter:image" content="{{ $path_del_banner }}">
 {{ end }}
 <meta name="twitter:description" content="{{ $description_plain | truncate 200 }}">
 {{ with .Param "twitter_author" }}<meta name="twitter:creator" content="@{{ . }}">{{ end }}


### PR DESCRIPTION
Añade la meta necesaria para que Facebook indexe correctamente la imagen publicada en el blog cuando se comparte una url del blog de Composcleta. En caso contrario, saca la primera imagen que encuentra que es el logo (comportamiento no deseable)